### PR TITLE
SOLR-15753: Include entity in v2 request logging

### DIFF
--- a/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
+++ b/solr/core/src/java/org/apache/solr/jersey/JerseyApplications.java
@@ -58,7 +58,8 @@ public class JerseyApplications {
       register(MessageBodyWriters.XmlMessageBodyWriter.class);
       register(MessageBodyWriters.CsvMessageBodyWriter.class);
       register(MessageBodyWriters.RawMessageBodyWriter.class);
-      register(JacksonJsonProvider.class);
+      register(JacksonJsonProvider.class, 5);
+      register(MessageBodyReaders.CachingJsonMessageBodyReader.class, 10);
       register(SolrJacksonMapper.class);
 
       // Request lifecycle logic

--- a/solr/core/src/java/org/apache/solr/jersey/MessageBodyReaders.java
+++ b/solr/core/src/java/org/apache/solr/jersey/MessageBodyReaders.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.jersey;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Type;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A collection point for various {@link MessageBodyReader} implementations. */
+public class MessageBodyReaders {
+
+  /**
+   * A JSON {@link MessageBodyReader} that caches request bodies for use later in the request
+   * lifecycle.
+   *
+   * @see CachingDelegatingMessageBodyReader
+   */
+  @Provider
+  @Consumes(MediaType.APPLICATION_JSON)
+  public static class CachingJsonMessageBodyReader extends CachingDelegatingMessageBodyReader
+      implements MessageBodyReader<Object> {
+    @Override
+    public MessageBodyReader<Object> getDelegate() {
+      return new JacksonJsonProvider();
+    }
+  }
+
+  /**
+   * Caches the deserialized request body in the {@link ContainerRequestContext} for use later in
+   * the request lifecycle.
+   *
+   * <p>This makes the request body accessible to any Jersey response filters or interceptors.
+   *
+   * @see PostRequestLoggingFilter
+   */
+  public abstract static class CachingDelegatingMessageBodyReader
+      implements MessageBodyReader<Object> {
+    public static final String DESERIALIZED_REQUEST_BODY_KEY = "request-body";
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Context ServiceLocator serviceLocator;
+    private final MessageBodyReader<Object> delegate;
+
+    public CachingDelegatingMessageBodyReader() {
+      this.delegate = getDelegate();
+    }
+
+    public abstract MessageBodyReader<Object> getDelegate();
+
+    @Override
+    public boolean isReadable(
+        Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+      return delegate.isReadable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public Object readFrom(
+        Class<Object> type,
+        Type genericType,
+        Annotation[] annotations,
+        MediaType mediaType,
+        MultivaluedMap<String, String> httpHeaders,
+        InputStream entityStream)
+        throws IOException, WebApplicationException {
+      final ContainerRequestContext requestContext = getRequestContext();
+      final Object object =
+          delegate.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+      if (requestContext != null) {
+        log.info("object is {}", object);
+        requestContext.setProperty(DESERIALIZED_REQUEST_BODY_KEY, object);
+      }
+      return object;
+    }
+
+    private ContainerRequestContext getRequestContext() {
+      return serviceLocator.getService(ContainerRequestContext.class);
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/jersey/PostRequestLoggingFilter.java
+++ b/solr/core/src/java/org/apache/solr/jersey/PostRequestLoggingFilter.java
@@ -18,6 +18,7 @@
 package org.apache.solr.jersey;
 
 import static org.apache.solr.common.params.CommonParams.LOG_PARAMS_LIST;
+import static org.apache.solr.jersey.MessageBodyReaders.CachingDelegatingMessageBodyReader.DESERIALIZED_REQUEST_BODY_KEY;
 import static org.apache.solr.jersey.PostRequestLoggingFilter.PRIORITY;
 import static org.apache.solr.jersey.RequestContextKeys.SOLR_QUERY_REQUEST;
 
@@ -88,12 +89,14 @@ public class PostRequestLoggingFilter implements ContainerResponseFilter {
 
     final Logger requestLogger = (solrConfig != null) ? coreRequestLogger : nonCoreRequestLogger;
     final String templatedPath = buildTemplatedPath();
+    final String bodyVal = buildRequestBodyString(requestContext);
     requestLogger.info(
         MarkerFactory.getMarker(templatedPath),
-        "method={} path={} query-params={{}} status={} QTime={}",
+        "method={} path={} query-params={{}} entity={} status={} QTime={}",
         requestContext.getMethod(),
         templatedPath,
         filterAndStringifyQueryParameters(requestContext.getUriInfo()),
+        bodyVal,
         response.responseHeader.status,
         response.responseHeader.qTime);
 
@@ -104,7 +107,7 @@ public class PostRequestLoggingFilter implements ContainerResponseFilter {
         && response.responseHeader.qTime >= solrConfig.slowQueryThresholdMillis) {
       slowCoreRequestLogger.warn(
           MarkerFactory.getMarker(templatedPath),
-          "method={} path={} query-params={{}} status={} QTime={}",
+          "method={} path={} query-params={{}} entity={} status={} QTime={}",
           requestContext.getMethod(),
           templatedPath,
           filterAndStringifyQueryParameters(requestContext.getUriInfo()),
@@ -123,6 +126,26 @@ public class PostRequestLoggingFilter implements ContainerResponseFilter {
 
     return String.format(Locale.ROOT, "%s%s", classPathAnnotationVal, methodPathAnnotationVal)
         .replaceAll("//", "/");
+  }
+
+  private String buildRequestBodyString(ContainerRequestContext requestContext) {
+    if (requestContext.getProperty(DESERIALIZED_REQUEST_BODY_KEY) == null) {
+      return "{}";
+    }
+
+    if (!(requestContext.getProperty(DESERIALIZED_REQUEST_BODY_KEY)
+        instanceof JacksonReflectMapWriter)) {
+      log.warn(
+          "Encountered unexpected request-body type {} for request {}; only {} expected.",
+          requestContext.getProperty(DESERIALIZED_REQUEST_BODY_KEY).getClass().getName(),
+          requestContext.getUriInfo().getPath(),
+          JacksonReflectMapWriter.class.getName());
+      return "{}";
+    }
+
+    return ((JacksonReflectMapWriter) requestContext.getProperty(DESERIALIZED_REQUEST_BODY_KEY))
+        .jsonStr()
+        .replace("\n", "");
   }
 
   private String filterAndStringifyQueryParameters(UriInfo uriInfo) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15753

# Description

Prior to this commit v2 requests were logged out by PostRequestLoggingFilter, but only the HTTP method, path, and query parameters made it into the message.  The request body, or entity, was excluded.

# Solution

This PR changes this by introducing a special JSON MessageBodyReader that caches the deserialized request body on Jersey's "ContainerRequestContext" object, so that it can be accessed and logged by PostRequestLoggingFilter.

# Tests

Manual testing; automated tests to follow.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.